### PR TITLE
Feat: generate separate debug symbols file

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-COMPILERFLAGS = -O2 -fPIC -Wall -Wextra -lpthread
+COMPILERFLAGS = -O2 -fPIC -Wall -Wextra -lpthread -g
 SERVEROBJECTS = obj/server.o
 .PHONY: all clean
 
@@ -6,6 +6,7 @@ all : obj b23_broker
 
 b23_broker: $(SERVEROBJECTS)
 	$(CC) $(COMPILERFLAGS) $^ -o $@ $(LINKLIBS)
+	objcopy --only-keep-debug $@ $@.debug && objcopy --strip-debug $@ && objcopy --add-gnu-debuglink $@.debug $@
 
 clean :
 	$(RM) vgcore.* obj/*.o b23_broker


### PR DESCRIPTION
Motivation: I would like to debug this program with gdb.

Adding debug info to the executable would produce a bigger file (from 36 KB to 100 KB), so I put it in a separate debug symbols file.
