### PR TITLE
Fix: use "-pthread" instead of "-lpthread"

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-COMPILERFLAGS = -O2 -fPIC -Wall -Wextra -lpthread
+COMPILERFLAGS = -O2 -fPIC -Wall -Wextra -pthread
 SERVEROBJECTS = obj/server.o
 .PHONY: all clean
 


### PR DESCRIPTION
Current compile flags don't work in my environment:

```console
$ gcc --version
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
Copyright (C) 2019 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ make
mkdir -p obj
cc -O2 -fPIC -Wall -Wextra -lpthread -c -o obj/server.o src/server.c
cc -O2 -fPIC -Wall -Wextra -lpthread obj/server.o -o b23_broker 
/usr/bin/ld: obj/server.o: in function `main':
server.c:(.text.startup+0x924): undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
make: *** [Makefile:8: b23_broker] Error 1
```

Using "-pthread" works fine.
