### PR TITLE
Feat: use "make DEBUG=1" to produce debug builds

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,5 +1,7 @@
 COMPILERFLAGS = -O2 -fPIC -Wall -Wextra -pthread
-DBGFLAGS = -g -DDEBUG
+ifeq ($(DEBUG), 1)
+	COMPILERFLAGS += -g -DDEBUG
+endif
 SERVEROBJECTS = obj/server.o
 LINKLIBS=
 .PHONY: all clean
@@ -9,11 +11,8 @@ all : obj b23_broker
 b23_broker: $(SERVEROBJECTS)
 	$(CC) $(COMPILERFLAGS) $^ -o $@ $(LINKLIBS)
 
-b23_broker_dbg: $(SERVEROBJECTS)
-	$(CC) $(DBGFLAGS) $(COMPILERFLAGS) $^ -o $@ $(LINKLIBS)
-
 clean:
-	$(RM) vgcore.* obj/*.o b23_broker b23_broker_dbg
+	$(RM) vgcore.* obj/*.o b23_broker
 
 obj/%.o: src/%.c
 	$(CC) $(COMPILERFLAGS) -c -o $@ $<


### PR DESCRIPTION
Hi. I think using conditional expressions can make things easier.

```console
$ git switch -d 'd819836b92381507f5cec46af1d07fb450f4904f' && \
> git restore . && \
> git clean -xfd && \
> make DEBUG=1 && \
> file ./obj/server.o ./b23_broker && \
> gdb -q ./b23_broker -ex 'info target' -ex 'q'
HEAD is now at d819836 feat: use "make DEBUG=1" to produce debug build
Removing b23_broker
Removing obj/
mkdir -p obj
cc -O2 -fPIC -Wall -Wextra -pthread -g -DDEBUG -c -o obj/server.o src/server.c
cc -O2 -fPIC -Wall -Wextra -pthread -g -DDEBUG obj/server.o -o b23_broker 
./obj/server.o: ELF 64-bit LSB relocatable, x86-64, version 1 (SYSV), with debug_info, not stripped
./b23_broker:   ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=7ce1726bdcd3755715c2a5f2f9c3af041b4cd492, for GNU/Linux 3.2.0, with debug_info, not stripped
Reading symbols from ./b23_broker...
Symbols from ".../b23.wtf/backend/b23_broker".
Local exec file:
        `.../b23.wtf/backend/b23_broker', file type elf64-x86-64.
        ...

```