### PR TITLE
Fix: create the "obj" directory in the "obj/%.o" target

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -4,7 +4,7 @@ SERVEROBJECTS = obj/server.o
 LINKLIBS=
 .PHONY: all clean
 
-all : obj b23_broker
+all : b23_broker
 
 b23_broker: $(SERVEROBJECTS)
 	$(CC) $(COMPILERFLAGS) $^ -o $@ $(LINKLIBS)
@@ -16,7 +16,6 @@ clean:
 	$(RM) vgcore.* obj/*.o b23_broker b23_broker_dbg
 
 obj/%.o: src/%.c
+	mkdir -p $(@D)
 	$(CC) $(COMPILERFLAGS) -c -o $@ $<
-obj:
-	mkdir -p obj
 


### PR DESCRIPTION
Before:

```console
$ git switch -d 4fd1d39b7365341f33390125b4de1abe8bb3aa37 && \
> git clean -xfd && \
> git restore . && \
> make b23_broker
HEAD is now at 4fd1d39 strip warning for hw
cc -O2 -fPIC -Wall -Wextra -pthread -c -o obj/server.o src/server.c
Assembler messages:
Fatal error: can't create obj/server.o: No such file or directory
make: *** [Makefile:19: obj/server.o] Error 1

```

After:

```console
$ git switch -d 67daa288ebc8ecf3aeb77e6e179bbca6fb7de6d7 && \
> git clean -xfd && \
> git restore . && \
> make b23_broker
HEAD is now at 67daa28 fix: create dir "obj" in target "obj/%.o"
Removing b23_broker
Removing obj/
mkdir -p obj
cc -O2 -fPIC -Wall -Wextra -pthread -c -o obj/server.o src/server.c
cc -O2 -fPIC -Wall -Wextra -pthread obj/server.o -o b23_broker

```

I learned this from [answer-1951111 § makefile - Create directories using make file - Stack Overflow](https://stackoverflow.com/questions/1950926/create-directories-using-make-file/1951111#1951111).