### PR TITLE
Fix: preserve "vote_id" in parameters

### DIFF
--- a/backend/src/server.c
+++ b/backend/src/server.c
@@ -150,6 +150,7 @@ bool is_whitelist_param(char *param) {
   if (strstr(param, "itemsId=") == param) return true;
   if (strstr(param, "tab=") == param) return true;
   if (strstr(param, "topic_id=") == param) return true;
+  if (strstr(param, "vote_id=") == param) return true;
   return false;
 }
 


### PR DESCRIPTION
Hi.

| Name | Link
|:- |:-
| Title | 投票- 复活组
| b23 link | https://b23.tv/ezoXzuL
| b23 redirect | http://t.bilibili.com/vote/h5/index?share_medium=android&share_plat=android&share_session_id=695d06d5-204b-4e13-9f1c-cd7be5adffda&share_source=GENERIC&share_tag=s_i&timestamp=1644203794&unique_k=ezoXzuL&vote_id=1976826#/result
| original clean link | http://t.bilibili.com/vote/h5/index
| new clean link | http://t.bilibili.com/vote/h5/index?vote_id=1976826#/result